### PR TITLE
use state instead of client for redirection

### DIFF
--- a/lib/auth_mvp_web/controllers/google_auth_controller.ex
+++ b/lib/auth_mvp_web/controllers/google_auth_controller.ex
@@ -22,7 +22,7 @@ defmodule AuthMvpWeb.GoogleAuthController do
     end
 
     jwt = AuthMvp.Token.generate_and_sign!(%{email: profile.email, session: session.id })
-    redirect(conn, external: "#{params["client"]}?jwt=#{jwt}")
+    redirect(conn, external: "#{params["state"]}?jwt=#{jwt}")
   end
 
 end


### PR DESCRIPTION
ref #3

The google callback endpoint was using the wrong name for the query parameter which contains the client url.
using `state` instead of `client` 