### PR TITLE
Default expiration time

### DIFF
--- a/lib/auth_mvp/token.ex
+++ b/lib/auth_mvp/token.ex
@@ -7,7 +7,7 @@ defmodule AuthMvp.Token do
 
   @impl true
   def token_config do
-    default_claims(exp: 31_537_000 ) # ~ 1 year in seconds
+    default_claims(default_exp: 31_537_000 ) # ~ 1 year in seconds
   end
 
 end


### PR DESCRIPTION
ref: #17
Use the `default_exp` configuration value to increase the default expiration time of the jwt